### PR TITLE
update list for required eeg sidecar json

### DIFF
--- a/validators/schemas/eeg.json
+++ b/validators/schemas/eeg.json
@@ -9,8 +9,9 @@
                 "InstitutionName": {"type": "string"},
                 "InstitutionAddress": {"type": "string"},
                 "Manufacturer": {"type": "string","minLength": 1},
-                "ManufacturersModelName": {"type": "string", "minLength": 1},
+                "ManufacturerModelName": {"type": "string", "minLength": 1},
                 "DeviceSerialNumber": {"type": "string"},
+                "DeviceSoftwareVersion": {"type": "string"},
                 "SoftwareVersions": {"type": "string"},
                 "PowerLineFrequency": {"type": "number"},
                 "SamplingFrequency": {"type": "number"},
@@ -24,7 +25,13 @@
                 "EEGReference": {"type" : "string"},
                 "EEGGround": {"type" : "string"},
                 "CapManufacturer": {"type": "string"},
-                "CapManufacturersModelName": {"type": "string"},
+                "CapModelName": {"type": "string"},
+                "HardwareFilters": {
+                  "anyOf": [
+                    {"type": "object", "additionalProperties": {"type":"object"}},
+                    {"type": "string", "pattern": "^n/a$"}
+                  ]
+                },
                 "SoftwareFilters": {
                   "anyOf": [
                     {"type": "object", "additionalProperties": {"type":"object"}},
@@ -39,6 +46,11 @@
         "required": [
             "TaskName",
             "SamplingFrequency",
+            "EEGChannelCount",
+            "EOGChannelCount",
+            "ECGChannelCount",
+            "EMGChannelCount",
+            "EEGReference",
             "PowerLineFrequency"
         ],
        "additionalProperties": false


### PR DESCRIPTION
Also some single letter fixes that we applied over the last weeks. E.g., `Manufacturer` vs `ManufacturerS`.

And I added "DeviceSoftwareVersion", "HardwareFilters", which you maybe forgot the first time you made the list?