### PR TITLE
add eeg schema to json schemas

### DIFF
--- a/validators/json.js
+++ b/validators/json.js
@@ -39,6 +39,8 @@ function checkUnits (file, sidecar) {
             schema = require('./schemas/dataset_description.json');
         } else if (file.name.endsWith("meg.json")) {
             schema = require('./schemas/meg.json');
+        } else if (file.name.endsWith("eeg.json")) {
+            schema = require('./schemas/eeg.json');
         } else if (file.name.endsWith("coordsystem.json")) {
             schema = require('./schemas/coordsystem.json');
         }


### PR DESCRIPTION
This was missing so that `_eeg.json` files are properly checked against the schema we have specified.

Now we finally get some helpful errors when validating an EEG dataset, such as:
```
	1: Invalid JSON file. The file is not formatted according the schema. (code: 55 - JSON_SCHEMA_VALIDATION_ERROR)
		./sub-05/eeg/sub-05_task-matchingpennies_eeg.json
			Evidence: .PowerLineFrequency should be number
```