### PR TITLE
check any of EEG or MEG requireds

### DIFF
--- a/validators/schemas/coordsystem.json
+++ b/validators/schemas/coordsystem.json
@@ -37,8 +37,19 @@
                 "DigitizedHeadPointsCoordinateUnits": {"type": "string"},
                 "DigitizedHeadPointsCoordinateSystemDescription": {"type": "string"}
                 },
-        "required": ["MEGCoordinateSystem",
-                     "MEGCoordinateUnits"
-                  ],
+        "anyOf": [
+            {
+                "required": [
+                    "MEGCoordinateSystem",
+                    "MEGCoordinateUnits"
+                ]
+            },
+            {
+                "required": [
+                    "EEGCoordinateSystem",
+                    "EEGCoordinateUnits"
+                ]
+            }
+        ],
         "additionalProperties": false
 }


### PR DESCRIPTION
fixes #7 

using `anyOf` as a check allows for either only EEG, or only MEG, or both ... but not neither